### PR TITLE
Block mob spawning in pyramids

### DIFF
--- a/src/main/java/draaft/draaft.java
+++ b/src/main/java/draaft/draaft.java
@@ -1,5 +1,6 @@
 package draaft;
 
+import draaft.world.PyramidChest;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.loader.api.FabricLoader;
 import org.apache.logging.log4j.Level;
@@ -28,6 +29,8 @@ public class draaft implements ModInitializer {
             Configurator.setLevel(MOD_ID, Level.DEBUG);
         }
         LOGGER.info("Draaft version: {}", DRAAFT_VERSION);
+
+        PyramidChest.registerPoi();
     }
 
     public static String getDraaftVersion() {

--- a/src/main/java/draaft/mixin/block/ChestBlockMixin.java
+++ b/src/main/java/draaft/mixin/block/ChestBlockMixin.java
@@ -1,0 +1,25 @@
+package draaft.mixin.block;
+
+import draaft.world.PyramidChest;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.ChestBlock;
+import net.minecraft.state.StateManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ChestBlock.class)
+public class ChestBlockMixin {
+    @Inject(method = "appendProperties", at = @At("TAIL"))
+    void appendProperties(StateManager.Builder<Block, BlockState> builder, CallbackInfo ci) {
+        builder.add(PyramidChest.PYRAMID_CHEST);
+    }
+
+    @ModifyArg(method = "<init>", at = @At(value = "INVOKE", target = "Lnet/minecraft/block/ChestBlock;setDefaultState(Lnet/minecraft/block/BlockState;)V"))
+    BlockState modifyDefaultState(BlockState bs) {
+        return bs.with(PyramidChest.PYRAMID_CHEST, false);
+    }
+}

--- a/src/main/java/draaft/mixin/structure/StructurePieceMixin.java
+++ b/src/main/java/draaft/mixin/structure/StructurePieceMixin.java
@@ -1,0 +1,38 @@
+package draaft.mixin.structure;
+
+import draaft.world.PyramidChest;
+import net.minecraft.block.BlockState;
+import net.minecraft.loot.LootTables;
+import net.minecraft.structure.StructurePiece;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.BlockBox;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.WorldAccess;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.Random;
+
+@Mixin(StructurePiece.class)
+public abstract class StructurePieceMixin {
+    @Unique
+    private static final String ADD_CHEST_TARGET = "addChest(Lnet/minecraft/world/WorldAccess;Lnet/minecraft/util/math/BlockBox;Ljava/util/Random;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/util/Identifier;Lnet/minecraft/block/BlockState;)Z";
+
+    @Unique
+    private static final String SET_BLOCK_STATE_TARGET = "Lnet/minecraft/world/WorldAccess;setBlockState(Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;I)Z";
+
+    @Redirect(method = ADD_CHEST_TARGET, at = @At(value = "INVOKE", target = SET_BLOCK_STATE_TARGET))
+    boolean modifyBlockState(
+        WorldAccess instance, BlockPos blockPos, BlockState blockState, int i,
+        WorldAccess world, BlockBox boundingBox, Random random, BlockPos pos, Identifier lootTableId, @Nullable BlockState block
+    ) {
+        if (LootTables.DESERT_PYRAMID_CHEST.equals(lootTableId)) {
+            return instance.setBlockState(blockPos, blockState.with(PyramidChest.PYRAMID_CHEST, true), i);
+        } else {
+            return instance.setBlockState(blockPos, blockState, i);
+        }
+    }
+}

--- a/src/main/java/draaft/mixin/world/SpawnHelperMixin.java
+++ b/src/main/java/draaft/mixin/world/SpawnHelperMixin.java
@@ -1,0 +1,29 @@
+package draaft.mixin.world;
+
+import draaft.draaft;
+import draaft.world.PyramidChest;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.world.SpawnHelper;
+import net.minecraft.world.chunk.WorldChunk;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+@Mixin(SpawnHelper.class)
+public abstract class SpawnHelperMixin {
+    @Unique
+    private static final String SPAWN_ENTITIES_IN_CHUNK_TARGET = "Lnet/minecraft/world/SpawnHelper;spawnEntitiesInChunk(Lnet/minecraft/entity/SpawnGroup;Lnet/minecraft/server/world/ServerWorld;Lnet/minecraft/world/chunk/WorldChunk;Lnet/minecraft/world/SpawnHelper$Checker;Lnet/minecraft/world/SpawnHelper$Runner;)V";
+
+    @ModifyArg(method = "spawn", at = @At(value = "INVOKE", target = SPAWN_ENTITIES_IN_CHUNK_TARGET), index = 3)
+    private static SpawnHelper.Checker addSpawnCondition(SpawnHelper.Checker checker) {
+        return (type, pos, chunk) -> {
+            if (chunk instanceof WorldChunk worldChunk && worldChunk.getWorld() instanceof ServerWorld world) {
+                return checker.test(type, pos, chunk) && PyramidChest.canSpawn(world, pos);
+            } else {
+                draaft.LOGGER.debug("Unexpected types while spawning");
+                return checker.test(type, pos, chunk);
+            }
+        };
+    }
+}

--- a/src/main/java/draaft/mixin/world/poi/PointOfInterestTypeAccessor.java
+++ b/src/main/java/draaft/mixin/world/poi/PointOfInterestTypeAccessor.java
@@ -1,0 +1,16 @@
+package draaft.mixin.world.poi;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.world.poi.PointOfInterestType;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import java.util.Set;
+
+@Mixin(PointOfInterestType.class)
+public interface PointOfInterestTypeAccessor {
+    @Invoker("register")
+    static PointOfInterestType draaft$register(String id, Set<BlockState> workStationStates, int ticketCount, int searchDistance) {
+        throw new AssertionError("unreachable");
+    }
+}

--- a/src/main/java/draaft/world/PyramidChest.java
+++ b/src/main/java/draaft/world/PyramidChest.java
@@ -1,0 +1,37 @@
+package draaft.world;
+
+import draaft.mixin.world.poi.PointOfInterestTypeAccessor;
+import net.minecraft.block.Blocks;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.state.property.BooleanProperty;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.poi.PointOfInterestStorage;
+
+import java.util.stream.Collectors;
+
+public class PyramidChest {
+    private static final String POI_ID = "pyramid_chest";
+
+    public static final BooleanProperty PYRAMID_CHEST = BooleanProperty.of(POI_ID);
+
+    public static void registerPoi() {
+        var states = Blocks.CHEST.getStateManager().getStates()
+            .stream()
+            .filter(state -> state.get(PYRAMID_CHEST))
+            .collect(Collectors.toSet());
+
+        PointOfInterestTypeAccessor.draaft$register(POI_ID, states, 0, 0);
+    }
+
+    public static boolean canSpawn(ServerWorld world, BlockPos blockPos) {
+        // chests always generate at y=53
+        if (blockPos.getY() < 50 || blockPos.getY() > 54) {
+            return true;
+        }
+
+        return world
+            .getPointOfInterestStorage()
+            .getInSquare(poi -> poi.toString().equals(POI_ID), blockPos, 8, PointOfInterestStorage.OccupationStatus.ANY)
+            .noneMatch(poi -> true);
+    }
+}

--- a/src/main/resources/draaft.mixins.json
+++ b/src/main/resources/draaft.mixins.json
@@ -3,6 +3,7 @@
   "package": "draaft.mixin",
   "compatibilityLevel": "JAVA_11",
   "mixins": [
+    "block.ChestBlockMixin",
     "enchantment.EnchantmentsMixin",
     "entity.boss.dragon.EnderDragonEntityMixin",
     "entity.boss.dragon.phase.HoldingPatternPhaseMixin",
@@ -19,6 +20,8 @@
     "screen.slot.TradeOutputSlotMixin",
     "server.world.ServerWorldMixin",
     "structure.IglooGeneratorMixin",
+    "structure.StructurePieceMixin",
+    "world.SpawnHelperMixin",
     "world.WanderingTraderManagerMixin",
     "world.biome.BambooJungleBiomeMixin",
     "world.biome.BambooJungleHillsBiomeMixin",
@@ -28,7 +31,8 @@
     "world.gen.decorator.BeehiveTreeDecoratorMixin",
     "world.gen.decorator.EndGatewayDecoratorMixin",
     "world.gen.decorator.LavaLakeDecoratorMixin",
-    "world.gen.feature.DefaultBiomeFeaturesMixin"
+    "world.gen.feature.DefaultBiomeFeaturesMixin",
+    "world.poi.PointOfInterestTypeAccessor"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Block mob spawning in bottom treasure based on a POI search. The POIs are created if a chest has a pyramid_chest=true property set.

Maybe a bit overcomplicated?