### PR TITLE
AllEnchanted feature, fix dedicated server crashes

### DIFF
--- a/src/main/java/draaft/mixin/enchantment/DamageEnchantmentMixin.java
+++ b/src/main/java/draaft/mixin/enchantment/DamageEnchantmentMixin.java
@@ -1,6 +1,7 @@
 package draaft.mixin.enchantment;
 
 import draaft.draaft;
+import draaft.world.EnchantUtils;
 import net.minecraft.enchantment.DamageEnchantment;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class DamageEnchantmentMixin {
     @Inject(method = "getMaxLevel", at = @At("HEAD"), cancellable = true)
     void getMaxLevel(CallbackInfoReturnable<Integer> cir) {
-        if (draaft.LEVEL_ONE_ENCHANTS) {
+        if (EnchantUtils.levelOneEnchants()) {
             cir.setReturnValue(1);
         }
     }

--- a/src/main/java/draaft/mixin/enchantment/DepthStriderEnchantmentMixin.java
+++ b/src/main/java/draaft/mixin/enchantment/DepthStriderEnchantmentMixin.java
@@ -1,6 +1,7 @@
 package draaft.mixin.enchantment;
 
 import draaft.draaft;
+import draaft.world.EnchantUtils;
 import net.minecraft.enchantment.DepthStriderEnchantment;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class DepthStriderEnchantmentMixin {
     @Inject(method = "getMaxLevel", at = @At("HEAD"), cancellable = true)
     void getMaxLevel(CallbackInfoReturnable<Integer> cir) {
-        if (draaft.LEVEL_ONE_ENCHANTS) {
+        if (EnchantUtils.levelOneEnchants()) {
             cir.setReturnValue(1);
         }
     }

--- a/src/main/java/draaft/mixin/enchantment/EfficiencyEnchantmentMixin.java
+++ b/src/main/java/draaft/mixin/enchantment/EfficiencyEnchantmentMixin.java
@@ -1,6 +1,7 @@
 package draaft.mixin.enchantment;
 
 import draaft.draaft;
+import draaft.world.EnchantUtils;
 import net.minecraft.enchantment.EfficiencyEnchantment;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class EfficiencyEnchantmentMixin {
     @Inject(method = "getMaxLevel", at = @At("HEAD"), cancellable = true)
     void getMaxLevel(CallbackInfoReturnable<Integer> cir) {
-        if (draaft.LEVEL_ONE_ENCHANTS) {
+        if (EnchantUtils.levelOneEnchants()) {
             cir.setReturnValue(1);
         }
     }

--- a/src/main/java/draaft/mixin/enchantment/FireAspectEnchantmentMixin.java
+++ b/src/main/java/draaft/mixin/enchantment/FireAspectEnchantmentMixin.java
@@ -1,6 +1,7 @@
 package draaft.mixin.enchantment;
 
 import draaft.draaft;
+import draaft.world.EnchantUtils;
 import net.minecraft.enchantment.FireAspectEnchantment;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class FireAspectEnchantmentMixin {
     @Inject(method = "getMaxLevel", at = @At("HEAD"), cancellable = true)
     void getMaxLevel(CallbackInfoReturnable<Integer> cir) {
-        if (draaft.LEVEL_ONE_ENCHANTS) {
+        if (EnchantUtils.levelOneEnchants()) {
             cir.setReturnValue(1);
         }
     }

--- a/src/main/java/draaft/mixin/enchantment/FrostWalkerEnchantmentMixin.java
+++ b/src/main/java/draaft/mixin/enchantment/FrostWalkerEnchantmentMixin.java
@@ -1,6 +1,7 @@
 package draaft.mixin.enchantment;
 
 import draaft.draaft;
+import draaft.world.EnchantUtils;
 import net.minecraft.enchantment.FrostWalkerEnchantment;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class FrostWalkerEnchantmentMixin {
     @Inject(method = "getMaxLevel", at = @At("HEAD"), cancellable = true)
     void getMaxLevel(CallbackInfoReturnable<Integer> cir) {
-        if (draaft.LEVEL_ONE_ENCHANTS) {
+        if (EnchantUtils.levelOneEnchants()) {
             cir.setReturnValue(1);
         }
     }

--- a/src/main/java/draaft/mixin/enchantment/ImpalingEnchantmentMixin.java
+++ b/src/main/java/draaft/mixin/enchantment/ImpalingEnchantmentMixin.java
@@ -1,6 +1,7 @@
 package draaft.mixin.enchantment;
 
 import draaft.draaft;
+import draaft.world.EnchantUtils;
 import net.minecraft.enchantment.ImpalingEnchantment;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class ImpalingEnchantmentMixin {
     @Inject(method = "getMaxLevel", at = @At("HEAD"), cancellable = true)
     void getMaxLevel(CallbackInfoReturnable<Integer> cir) {
-        if (draaft.LEVEL_ONE_ENCHANTS) {
+        if (EnchantUtils.levelOneEnchants()) {
             cir.setReturnValue(1);
         }
     }

--- a/src/main/java/draaft/mixin/enchantment/KnockbackEnchantmentMixin.java
+++ b/src/main/java/draaft/mixin/enchantment/KnockbackEnchantmentMixin.java
@@ -1,6 +1,7 @@
 package draaft.mixin.enchantment;
 
 import draaft.draaft;
+import draaft.world.EnchantUtils;
 import net.minecraft.enchantment.KnockbackEnchantment;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class KnockbackEnchantmentMixin {
     @Inject(method = "getMaxLevel", at = @At("HEAD"), cancellable = true)
     void getMaxLevel(CallbackInfoReturnable<Integer> cir) {
-        if (draaft.LEVEL_ONE_ENCHANTS) {
+        if (EnchantUtils.levelOneEnchants()) {
             cir.setReturnValue(1);
         }
     }

--- a/src/main/java/draaft/mixin/enchantment/LoyaltyEnchantmentMixin.java
+++ b/src/main/java/draaft/mixin/enchantment/LoyaltyEnchantmentMixin.java
@@ -1,6 +1,7 @@
 package draaft.mixin.enchantment;
 
 import draaft.draaft;
+import draaft.world.EnchantUtils;
 import net.minecraft.enchantment.LoyaltyEnchantment;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class LoyaltyEnchantmentMixin {
     @Inject(method = "getMaxLevel", at = @At("HEAD"), cancellable = true)
     void getMaxLevel(CallbackInfoReturnable<Integer> cir) {
-        if (draaft.LEVEL_ONE_ENCHANTS) {
+        if (EnchantUtils.levelOneEnchants()) {
             cir.setReturnValue(1);
         }
     }

--- a/src/main/java/draaft/mixin/enchantment/LuckEnchantmentMixin.java
+++ b/src/main/java/draaft/mixin/enchantment/LuckEnchantmentMixin.java
@@ -1,6 +1,7 @@
 package draaft.mixin.enchantment;
 
 import draaft.draaft;
+import draaft.world.EnchantUtils;
 import net.minecraft.enchantment.LuckEnchantment;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class LuckEnchantmentMixin {
     @Inject(method = "getMaxLevel", at = @At("HEAD"), cancellable = true)
     void getMaxLevel(CallbackInfoReturnable<Integer> cir) {
-        if (draaft.LEVEL_ONE_ENCHANTS) {
+        if (EnchantUtils.levelOneEnchants()) {
             cir.setReturnValue(1);
         }
     }

--- a/src/main/java/draaft/mixin/enchantment/LureEnchantmentMixin.java
+++ b/src/main/java/draaft/mixin/enchantment/LureEnchantmentMixin.java
@@ -1,6 +1,7 @@
 package draaft.mixin.enchantment;
 
 import draaft.draaft;
+import draaft.world.EnchantUtils;
 import net.minecraft.enchantment.LureEnchantment;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class LureEnchantmentMixin {
     @Inject(method = "getMaxLevel", at = @At("HEAD"), cancellable = true)
     void getMaxLevel(CallbackInfoReturnable<Integer> cir) {
-        if (draaft.LEVEL_ONE_ENCHANTS) {
+        if (EnchantUtils.levelOneEnchants()) {
             cir.setReturnValue(1);
         }
     }

--- a/src/main/java/draaft/mixin/enchantment/PowerEnchantmentMixin.java
+++ b/src/main/java/draaft/mixin/enchantment/PowerEnchantmentMixin.java
@@ -1,6 +1,6 @@
 package draaft.mixin.enchantment;
 
-import draaft.draaft;
+import draaft.world.EnchantUtils;
 import net.minecraft.enchantment.PowerEnchantment;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class PowerEnchantmentMixin {
     @Inject(method = "getMaxLevel", at = @At("HEAD"), cancellable = true)
     void getMaxLevel(CallbackInfoReturnable<Integer> cir) {
-        if (draaft.LEVEL_ONE_ENCHANTS) {
+        if (EnchantUtils.levelOneEnchants()) {
             cir.setReturnValue(1);
         }
     }

--- a/src/main/java/draaft/mixin/enchantment/ProtectionEnchantmentMixin.java
+++ b/src/main/java/draaft/mixin/enchantment/ProtectionEnchantmentMixin.java
@@ -1,6 +1,7 @@
 package draaft.mixin.enchantment;
 
 import draaft.draaft;
+import draaft.world.EnchantUtils;
 import net.minecraft.enchantment.ProtectionEnchantment;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class ProtectionEnchantmentMixin {
     @Inject(method = "getMaxLevel", at = @At("HEAD"), cancellable = true)
     void getMaxLevel(CallbackInfoReturnable<Integer> cir) {
-        if (draaft.LEVEL_ONE_ENCHANTS) {
+        if (EnchantUtils.levelOneEnchants()) {
             cir.setReturnValue(1);
         }
     }

--- a/src/main/java/draaft/mixin/enchantment/PunchEnchantmentMixin.java
+++ b/src/main/java/draaft/mixin/enchantment/PunchEnchantmentMixin.java
@@ -1,6 +1,7 @@
 package draaft.mixin.enchantment;
 
 import draaft.draaft;
+import draaft.world.EnchantUtils;
 import net.minecraft.enchantment.PunchEnchantment;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class PunchEnchantmentMixin {
     @Inject(method = "getMaxLevel", at = @At("HEAD"), cancellable = true)
     void getMaxLevel(CallbackInfoReturnable<Integer> cir) {
-        if (draaft.LEVEL_ONE_ENCHANTS) {
+        if (EnchantUtils.levelOneEnchants()) {
             cir.setReturnValue(1);
         }
     }

--- a/src/main/java/draaft/mixin/enchantment/QuickChargeEnchantmentMixin.java
+++ b/src/main/java/draaft/mixin/enchantment/QuickChargeEnchantmentMixin.java
@@ -1,6 +1,7 @@
 package draaft.mixin.enchantment;
 
 import draaft.draaft;
+import draaft.world.EnchantUtils;
 import net.minecraft.enchantment.QuickChargeEnchantment;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class QuickChargeEnchantmentMixin {
     @Inject(method = "getMaxLevel", at = @At("HEAD"), cancellable = true)
     void getMaxLevel(CallbackInfoReturnable<Integer> cir) {
-        if (draaft.LEVEL_ONE_ENCHANTS) {
+        if (EnchantUtils.levelOneEnchants()) {
             cir.setReturnValue(1);
         }
     }

--- a/src/main/java/draaft/mixin/enchantment/RespirationEnchantmentMixin.java
+++ b/src/main/java/draaft/mixin/enchantment/RespirationEnchantmentMixin.java
@@ -1,6 +1,7 @@
 package draaft.mixin.enchantment;
 
 import draaft.draaft;
+import draaft.world.EnchantUtils;
 import net.minecraft.enchantment.RespirationEnchantment;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class RespirationEnchantmentMixin {
     @Inject(method = "getMaxLevel", at = @At("HEAD"), cancellable = true)
     void getMaxLevel(CallbackInfoReturnable<Integer> cir) {
-        if (draaft.LEVEL_ONE_ENCHANTS) {
+        if (EnchantUtils.levelOneEnchants()) {
             cir.setReturnValue(1);
         }
     }

--- a/src/main/java/draaft/mixin/enchantment/RiptideEnchantmentMixin.java
+++ b/src/main/java/draaft/mixin/enchantment/RiptideEnchantmentMixin.java
@@ -1,6 +1,7 @@
 package draaft.mixin.enchantment;
 
 import draaft.draaft;
+import draaft.world.EnchantUtils;
 import net.minecraft.enchantment.RiptideEnchantment;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class RiptideEnchantmentMixin {
     @Inject(method = "getMaxLevel", at = @At("HEAD"), cancellable = true)
     void getMaxLevel(CallbackInfoReturnable<Integer> cir) {
-        if (draaft.LEVEL_ONE_ENCHANTS) {
+        if (EnchantUtils.levelOneEnchants()) {
             cir.setReturnValue(1);
         }
     }

--- a/src/main/java/draaft/mixin/enchantment/SoulSpeedEnchantmentMixin.java
+++ b/src/main/java/draaft/mixin/enchantment/SoulSpeedEnchantmentMixin.java
@@ -1,6 +1,7 @@
 package draaft.mixin.enchantment;
 
 import draaft.draaft;
+import draaft.world.EnchantUtils;
 import net.minecraft.enchantment.SoulSpeedEnchantment;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class SoulSpeedEnchantmentMixin {
     @Inject(method = "getMaxLevel", at = @At("HEAD"), cancellable = true)
     void getMaxLevel(CallbackInfoReturnable<Integer> cir) {
-        if (draaft.LEVEL_ONE_ENCHANTS) {
+        if (EnchantUtils.levelOneEnchants()) {
             cir.setReturnValue(1);
         }
     }

--- a/src/main/java/draaft/mixin/enchantment/SweepingEnchantmentMixin.java
+++ b/src/main/java/draaft/mixin/enchantment/SweepingEnchantmentMixin.java
@@ -1,6 +1,7 @@
 package draaft.mixin.enchantment;
 
 import draaft.draaft;
+import draaft.world.EnchantUtils;
 import net.minecraft.enchantment.SweepingEnchantment;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class SweepingEnchantmentMixin {
     @Inject(method = "getMaxLevel", at = @At("HEAD"), cancellable = true)
     void getMaxLevel(CallbackInfoReturnable<Integer> cir) {
-        if (draaft.LEVEL_ONE_ENCHANTS) {
+        if (EnchantUtils.levelOneEnchants()) {
             cir.setReturnValue(1);
         }
     }

--- a/src/main/java/draaft/mixin/enchantment/ThornsEnchantmentMixin.java
+++ b/src/main/java/draaft/mixin/enchantment/ThornsEnchantmentMixin.java
@@ -1,6 +1,7 @@
 package draaft.mixin.enchantment;
 
 import draaft.draaft;
+import draaft.world.EnchantUtils;
 import net.minecraft.enchantment.ThornsEnchantment;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class ThornsEnchantmentMixin {
     @Inject(method = "getMaxLevel", at = @At("HEAD"), cancellable = true)
     void getMaxLevel(CallbackInfoReturnable<Integer> cir) {
-        if (draaft.LEVEL_ONE_ENCHANTS) {
+        if (EnchantUtils.levelOneEnchants()) {
             cir.setReturnValue(1);
         }
     }

--- a/src/main/java/draaft/mixin/enchantment/UnbreakingEnchantmentMixin.java
+++ b/src/main/java/draaft/mixin/enchantment/UnbreakingEnchantmentMixin.java
@@ -1,6 +1,7 @@
 package draaft.mixin.enchantment;
 
 import draaft.draaft;
+import draaft.world.EnchantUtils;
 import net.minecraft.enchantment.UnbreakingEnchantment;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -11,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 public abstract class UnbreakingEnchantmentMixin {
     @Inject(method = "getMaxLevel", at = @At("HEAD"), cancellable = true)
     void getMaxLevel(CallbackInfoReturnable<Integer> cir) {
-        if (draaft.LEVEL_ONE_ENCHANTS) {
+        if (EnchantUtils.levelOneEnchants()) {
             cir.setReturnValue(1);
         }
     }

--- a/src/main/java/draaft/mixin/item/ItemClientMixin.java
+++ b/src/main/java/draaft/mixin/item/ItemClientMixin.java
@@ -8,18 +8,31 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
 import net.minecraft.util.Rarity;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Item.class)
-public abstract class ItemMixin implements ItemConvertible {
+public abstract class ItemClientMixin implements ItemConvertible {
+    @Unique
+    private static boolean isBucket(Item item) {
+        return item.equals(Items.BUCKET)
+            || item.equals(Items.LAVA_BUCKET)
+            || item.equals(Items.WATER_BUCKET)
+            || item.equals(Items.TROPICAL_FISH_BUCKET)
+            || item.equals(Items.PUFFERFISH_BUCKET)
+            || item.equals(Items.COD_BUCKET)
+            || item.equals(Items.SALMON_BUCKET)
+            || item.equals(Items.MILK_BUCKET);
+    }
+
     @Inject(method = "hasGlint", at = @At("HEAD"), cancellable = true)
     void hasGlint(ItemStack stack, CallbackInfoReturnable<Boolean> cir) {
         var world = MinecraftClient.getInstance().world;
 
         if (world != null && WorldClientInfo.get(world).enchantedBucket()) {
-            if (stack.getItem().equals(Items.BUCKET) || stack.getItem().equals(Items.LAVA_BUCKET) || stack.getItem().equals(Items.WATER_BUCKET) || stack.getItem().equals(Items.TROPICAL_FISH_BUCKET) || stack.getItem().equals(Items.PUFFERFISH_BUCKET) || stack.getItem().equals(Items.COD_BUCKET) || stack.getItem().equals(Items.SALMON_BUCKET) || stack.getItem().equals(Items.MILK_BUCKET)) {
+            if (isBucket(stack.getItem())) {
                 cir.setReturnValue(true);
             }
         }
@@ -30,7 +43,7 @@ public abstract class ItemMixin implements ItemConvertible {
         var world = MinecraftClient.getInstance().world;
 
         if (world != null && WorldClientInfo.get(world).enchantedBucket()) {
-            if (stack.getItem().equals(Items.BUCKET) || stack.getItem().equals(Items.LAVA_BUCKET) || stack.getItem().equals(Items.WATER_BUCKET) || stack.getItem().equals(Items.TROPICAL_FISH_BUCKET) || stack.getItem().equals(Items.PUFFERFISH_BUCKET) || stack.getItem().equals(Items.COD_BUCKET) || stack.getItem().equals(Items.SALMON_BUCKET) || stack.getItem().equals(Items.MILK_BUCKET)) {
+            if (isBucket(stack.getItem())) {
                 cir.setReturnValue(Rarity.EPIC);
             }
         }

--- a/src/main/java/draaft/mixin/item/ItemStackMixin.java
+++ b/src/main/java/draaft/mixin/item/ItemStackMixin.java
@@ -1,6 +1,6 @@
 package draaft.mixin.item;
 
-import draaft.draaft;
+import draaft.world.EnchantUtils;
 import net.minecraft.enchantment.Enchantment;
 import net.minecraft.enchantment.Enchantments;
 import net.minecraft.item.ItemConvertible;
@@ -25,7 +25,7 @@ public abstract class ItemStackMixin {
 
     @Inject(method = "<init>(Lnet/minecraft/item/ItemConvertible;I)V", at = @At("TAIL"))
     void ItemStack(ItemConvertible item, int count, CallbackInfo ci) {
-        if (!draaft.LEVEL_ONE_ENCHANTS) {
+        if (!EnchantUtils.levelOneEnchants()) {
             return;
         }
 
@@ -43,9 +43,9 @@ public abstract class ItemStackMixin {
         List<Enchantment> crossbowEnchants = List.of(Enchantments.PIERCING, Enchantments.MENDING, Enchantments.QUICK_CHARGE, Enchantments.UNBREAKING);
         Map<String, List<Enchantment>> enchantmentMap = Map.ofEntries(Map.entry("pickaxe", pickaxeshovelEnchants), Map.entry("shovel", pickaxeshovelEnchants), Map.entry("_axe", axehoeEnchants), Map.entry("hoe", axehoeEnchants), Map.entry("shears", axehoeEnchants), Map.entry("sword", swordEnchants), Map.entry("helmet", helmetEnchants), Map.entry("chestplate", chestplateleggingsEnchants), Map.entry("leggings", chestplateleggingsEnchants), Map.entry("boots", bootsEnchants), Map.entry("compass", compassEnchants), Map.entry("flint_and_steel", fnsoasEnchants), Map.entry("_on_a_stick", fnsoasEnchants), Map.entry("shield", fnsoasEnchants), Map.entry("elytra", fnsoasEnchants), Map.entry("fishing_rod", rodEnchants), Map.entry("bow", bowEnchants), Map.entry("trident", tridentEnchants), Map.entry("crossbow", crossbowEnchants));
 
-        if (item != null && !item.asItem().getName().toString().equals("bowl")) {
+        if (item != null && !item.asItem().getTranslationKey().contains("bowl")) {
             for (String id : enchantmentMap.keySet()) {
-                if (item.asItem().getName().toString().contains(id)) {
+                if (item.asItem().getTranslationKey().contains(id)) {
                     ListTag listTag = new ListTag();
                     for (Enchantment enchantment : enchantmentMap.get(id)) {
                         CompoundTag compoundTag = new CompoundTag();

--- a/src/main/java/draaft/persistent/WorldManifest.java
+++ b/src/main/java/draaft/persistent/WorldManifest.java
@@ -4,6 +4,8 @@ import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
 import draaft.mixin.server.MinecraftServerAccessor;
 import draaft.world.WorldClientInfo;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.resource.Resource;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.Identifier;
@@ -34,6 +36,10 @@ public class WorldManifest {
     }
 
     public static WorldManifest get(MinecraftServer server) {
+        if (FabricLoader.getInstance().getEnvironmentType() == EnvType.SERVER) {
+            return new WorldManifest();
+        }
+
         //noinspection resource
         var resxManager = ((MinecraftServerAccessor) server)
             .draaft$serverResourceManager()

--- a/src/main/java/draaft/world/EnchantUtils.java
+++ b/src/main/java/draaft/world/EnchantUtils.java
@@ -1,0 +1,34 @@
+package draaft.world;
+
+import draaft.persistent.WorldManifest;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.loader.api.FabricLoader;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.server.MinecraftServer;
+import org.jetbrains.annotations.Nullable;
+
+public abstract class EnchantUtils {
+    public static boolean levelOneEnchants() {
+        if (
+            FabricLoader.getInstance().getEnvironmentType() == EnvType.CLIENT
+                && MinecraftClientWrapper.available()
+                && MinecraftClientWrapper.getServer() != null
+        ) {
+            var server = MinecraftClientWrapper.getServer();
+
+            return WorldManifest.get(server).on(WorldManifest.Feature.LEVEL_ONE_ENCHANTS);
+        } else {
+            return false;
+        }
+    }
+
+    private static class MinecraftClientWrapper {
+        static boolean available() {
+            return MinecraftClient.getInstance() != null;
+        }
+
+        static @Nullable MinecraftServer getServer() {
+            return MinecraftClient.getInstance().getServer();
+        }
+    }
+}

--- a/src/main/resources/draaft.mixins.json
+++ b/src/main/resources/draaft.mixins.json
@@ -43,7 +43,6 @@
     "entity.passive.CatEntityMixin",
     "entity.passive.RabbitEntityMixin",
     "entity.projectile.thrown.EnderPearlEntityMixin",
-    "item.ItemMixin",
     "item.ItemsMixin",
     "item.ItemStackMixin",
     "screen.slot.TradeOutputSlotMixin",
@@ -78,6 +77,7 @@
     "client.gui.screen.options.OptionsScreenMixin",
     "client.network.ClientPlayNetworkHandlerMixin",
     "client.resource.SplashTextResourceSupplierMixin",
+    "item.ItemClientMixin",
     "compat.InGameTimerMixin"
   ]
 }


### PR DESCRIPTION
AllEnchanted is always off on dedicated servers, but I don't think there's a reason to support them for anything beyond pregenning so it's ok. Fixed a crash in `ItemStackMixin`, `getName` is unavailable on servers.