### PR TITLE
Dev mode authentication

### DIFF
--- a/src/main/java/draaft/client/DraaftAuth.java
+++ b/src/main/java/draaft/client/DraaftAuth.java
@@ -7,6 +7,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 
+import java.io.IOException;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
@@ -23,21 +24,7 @@ public class DraaftAuth {
 
         String clientToken;
         try {
-            var versionReq = HttpRequest.newBuilder(draaftServices.apiBase().resolve("/version"))
-                .GET()
-                .build();
-
-            var versionResp = http.send(versionReq, HttpResponse.BodyHandlers.ofString());
-            var version = ServerClient.GSON.fromJson(versionResp.body(), int.class);
-
-            if (version != DraaftServices.API_VERSION) {
-                LOGGER.error("drAAft server version not supported (expected {}, got {}).", DraaftServices.API_VERSION, version);
-
-                DraaftToast.showError(
-                    new TranslatableText("draaft.login.failed.title"),
-                    new TranslatableText("draaft.login.failed.unsupportedVersion")
-                );
-
+            if (!verifyServerVersion(draaftServices, http)) {
                 return null;
             }
 
@@ -75,6 +62,55 @@ public class DraaftAuth {
         }
 
         return clientToken;
+    }
+
+    public static @Nullable String authenticateDevMode(DraaftServices draaftServices, HttpClient http, String username) {
+        try {
+            assert draaftServices.supportsDevAuth();
+
+            if (!verifyServerVersion(draaftServices, http)) {
+                return null;
+            }
+
+            var req = HttpRequest.newBuilder(draaftServices.apiBase().resolve("/dev/becomeuser?username=" + username))
+                .POST(HttpRequest.BodyPublishers.noBody())
+                .build();
+
+            var resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+
+            return ServerClient.GSON.fromJson(resp.body(), LoginResponse.class).token;
+        } catch (InterruptedException | IOException e) {
+            LOGGER.error("Could not contact drAAft server (dev mode)", e);
+
+            DraaftToast.showError(
+                new TranslatableText("draaft.login.failed.title"),
+                new TranslatableText("draaft.login.failed.errorContactingDraaft")
+            );
+
+            return null;
+        }
+    }
+
+    private static boolean verifyServerVersion(DraaftServices draaftServices, HttpClient http) throws IOException, InterruptedException {
+        var versionReq = HttpRequest.newBuilder(draaftServices.apiBase().resolve("/version"))
+            .GET()
+            .build();
+
+        var versionResp = http.send(versionReq, HttpResponse.BodyHandlers.ofString());
+        var version = ServerClient.GSON.fromJson(versionResp.body(), int.class);
+
+        if (version != DraaftServices.API_VERSION) {
+            LOGGER.error("drAAft server version not supported (expected {}, got {}).", DraaftServices.API_VERSION, version);
+
+            DraaftToast.showError(
+                new TranslatableText("draaft.login.failed.title"),
+                new TranslatableText("draaft.login.failed.unsupportedVersion")
+            );
+
+            return false;
+        } else {
+            return true;
+        }
     }
 
     // GSON can't deserialize to method-local classes

--- a/src/main/java/draaft/client/DraaftServices.java
+++ b/src/main/java/draaft/client/DraaftServices.java
@@ -9,14 +9,16 @@ public record DraaftServices(
     URI apiBase,
     URI webBase,
     // note: the origin MUST NOT end with a trailing slash
-    String webOrigin
+    String webOrigin,
+    boolean supportsDevAuth
 ) {
     public final static int API_VERSION = 1;
 
     public final static DraaftServices DEFAULT = new DraaftServices(
         URI.create("https://api.disrespec.tech/"),
         URI.create("https://disrespec.tech/draaft/"),
-        "https://disrespec.tech"
+        "https://disrespec.tech",
+        false
     );
 
     public static @Nullable DraaftServices fromJvmArgs() {
@@ -24,7 +26,8 @@ public record DraaftServices(
             return new DraaftServices(
                 URI.create(System.getProperty("DRAAFT_API_BASE", "http://localhost:8000/")),
                 URI.create(System.getProperty("DRAAFT_WEB_BASE", "http://localhost:8080/draaft/")),
-                System.getProperty("DRAAFT_WEB_ORIGIN", "http://localhost:8080")
+                System.getProperty("DRAAFT_WEB_ORIGIN", "http://localhost:8080"),
+                true
             );
         } else {
             return null;

--- a/src/main/java/draaft/client/ServerClient.java
+++ b/src/main/java/draaft/client/ServerClient.java
@@ -16,6 +16,7 @@ import draaft.client.ws.events.RoomMemberEvents;
 import draaft.client.ws.events.RoomStateEvents;
 import draaft.client.ws.outgoing.GameUpdate;
 import draaft.draaft;
+import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.text.TranslatableText;
@@ -200,14 +201,23 @@ public class ServerClient {
             .version(HttpClient.Version.HTTP_1_1) // HTTP 2 is not supported by fastapi
             .build();
 
-        logger.info("Contacting Minecraft auth server...");
-        var serverID = MojangAuth.joinDraaftServer();
-        if (serverID == null) {
-            return;
+        String clientToken;
+
+        if (FabricLoader.getInstance().isDevelopmentEnvironment() && draaftServices.supportsDevAuth()) {
+            var username = System.getProperty("DRAAFT_USERNAME", MinecraftClient.getInstance().getSession().getUsername());
+
+            clientToken = DraaftAuth.authenticateDevMode(draaftServices, httpClient, username);
+        } else {
+            logger.info("Contacting Minecraft auth server...");
+            var serverID = MojangAuth.joinDraaftServer();
+            if (serverID == null) {
+                return;
+            }
+
+            logger.info("Contacting drAAft server...");
+            clientToken = DraaftAuth.authenticate(draaftServices, httpClient, serverID);
         }
 
-        logger.info("Contacting drAAft server...");
-        String clientToken = DraaftAuth.authenticate(draaftServices, httpClient, serverID);
         if (clientToken == null) {
             return;
         }


### PR DESCRIPTION
Skip Mojang auth in development mode and use /dev/becomeuser instead.

This makes `runClient` usable.