### PR TITLE
Default to login with OTP

### DIFF
--- a/src/main/java/draaft/client/AuthTokenServer.java
+++ b/src/main/java/draaft/client/AuthTokenServer.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.Nullable;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.http.HttpClient;
 import java.nio.charset.StandardCharsets;
 
 /**
@@ -17,7 +18,7 @@ public class AuthTokenServer {
     private final HttpServer server;
     private final DraaftServices draaftServices;
     private final String token;
-    private final @Nullable String otp;
+    private @Nullable String otp;
 
     public AuthTokenServer(DraaftServices draaftServices, String token, String otp) {
         this.draaftServices = draaftServices;
@@ -45,10 +46,11 @@ public class AuthTokenServer {
         }
     }
 
-    public String webLoginUri() {
+    public String webLoginUri(DraaftServices draaftServices, HttpClient httpClient, String clientToken) {
         if (this.otp == null) {
             return "%s?auth_port=%d".formatted(this.draaftServices.webBase().toString(), this.port());
         }
+        this.otp = DraaftAuth.getOTP(draaftServices, httpClient, clientToken);
         return "%s?otp=%s".formatted(this.draaftServices.webBase().toString(), this.otp);
     }
 

--- a/src/main/java/draaft/client/AuthTokenServer.java
+++ b/src/main/java/draaft/client/AuthTokenServer.java
@@ -3,6 +3,7 @@ package draaft.client;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
+import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -16,29 +17,39 @@ public class AuthTokenServer {
     private final HttpServer server;
     private final DraaftServices draaftServices;
     private final String token;
+    private final @Nullable String otp;
 
-    public AuthTokenServer(DraaftServices draaftServices, String token) {
+    public AuthTokenServer(DraaftServices draaftServices, String token, String otp) {
         this.draaftServices = draaftServices;
         this.token = token;
+        this.otp = otp;
 
-        // Bind to any ephemeral free port, listen only for local connections
-        var bindAddr = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
+        if (otp == null) {
+            // Bind to any ephemeral free port, listen only for local connections
+            var bindAddr = new InetSocketAddress(InetAddress.getLoopbackAddress(), 0);
 
-        try {
-            // 0 indicates the default backlog size
-            this.server = HttpServer.create(bindAddr, 0);
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to create an HTTP server for auth token passing", e);
+            try {
+                // 0 indicates the default backlog size
+                this.server = HttpServer.create(bindAddr, 0);
+            } catch (IOException e) {
+                throw new RuntimeException("Failed to create an HTTP server for auth token passing", e);
+            }
+
+            this.server.createContext("/", new Handler());
+
+            this.server.setExecutor(null);
+            this.server.start();
         }
-
-        this.server.createContext("/", new Handler());
-
-        this.server.setExecutor(null);
-        this.server.start();
+        else {
+            this.server = null;
+        }
     }
 
     public String webLoginUri() {
-        return "%s?auth_port=%d".formatted(this.draaftServices.webBase().toString(), this.port());
+        if (this.otp == null) {
+            return "%s?auth_port=%d".formatted(this.draaftServices.webBase().toString(), this.port());
+        }
+        return "%s?otp=%s".formatted(this.draaftServices.webBase().toString(), this.otp);
     }
 
     /**

--- a/src/main/java/draaft/client/DraaftAuth.java
+++ b/src/main/java/draaft/client/DraaftAuth.java
@@ -8,9 +8,11 @@ import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
+import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.Objects;
 
 import static draaft.draaft.MOD_ID;
 
@@ -110,6 +112,27 @@ public class DraaftAuth {
             return false;
         } else {
             return true;
+        }
+    }
+
+    public static String getOTP(DraaftServices draaftServices, HttpClient http, String token)  {
+        var uri = draaftServices.apiBase().resolve("/otp");
+        var req = HttpRequest.newBuilder(uri)
+            .header("token", token)
+            .GET().build();
+
+        try {
+            var resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+            var otp = resp.body();
+
+            if (Objects.equals(otp, "false")) {
+                LOGGER.error("drAAft server refused to generate OTP.");
+                return null;
+            }
+            return otp;
+        } catch (Throwable t) {
+            LOGGER.error("drAAft server could not be contacted to generate OTP / refused to generate OTP.");
+            return null;
         }
     }
 

--- a/src/main/java/draaft/client/ServerClient.java
+++ b/src/main/java/draaft/client/ServerClient.java
@@ -226,7 +226,10 @@ public class ServerClient {
 
         logger.info("Successfully authenticated with the server, received {} long client token", clientToken.length());
 
-        var authTokenServer = new AuthTokenServer(draaftServices, clientToken);
+        // See if we can log in through OTP first, which is more reliable due to chrome network permissions, if possible
+        var otp = DraaftAuth.getOTP(draaftServices, httpClient, clientToken);
+
+        var authTokenServer = new AuthTokenServer(draaftServices, clientToken, otp);
 
         INSTANCE = new ServerClient(authTokenServer, httpClient, clientToken, draaftServices);
 

--- a/src/main/java/draaft/client/ServerClient.java
+++ b/src/main/java/draaft/client/ServerClient.java
@@ -191,7 +191,7 @@ public class ServerClient {
     public static void login(DraaftServices draaftServices) {
         if (INSTANCE != null) {
             // If already logged in just open the browser link
-            INSTANCE.openWebLoginUri();
+            INSTANCE.openWebLoginUri(draaftServices);
 
             return;
         }
@@ -233,11 +233,11 @@ public class ServerClient {
 
         INSTANCE = new ServerClient(authTokenServer, httpClient, clientToken, draaftServices);
 
-        INSTANCE.openWebLoginUri();
+        INSTANCE.openWebLoginUri(draaftServices);
     }
 
-    private void openWebLoginUri() {
-        var uri = this.authTokenServer.webLoginUri();
+    private void openWebLoginUri(DraaftServices draaftServices) {
+        var uri = this.authTokenServer.webLoginUri(draaftServices, httpClient, token);
 
         // TODO(me-nx): shift click tooltip?
 


### PR DESCRIPTION
Keeps old auth flow for fallback, because OTP is based around cloudflare IP, which we don't have in testing environments or in other peoples' deploys (necessarily) 